### PR TITLE
Fix network error handling

### DIFF
--- a/SnapChef/Presentation/View/CentralTabView/PhotoTabViewModel.swift
+++ b/SnapChef/Presentation/View/CentralTabView/PhotoTabViewModel.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import SwiftData
+import Observation
 
 @MainActor
 @Observable

--- a/SnapChef/Service/NetworkService.swift
+++ b/SnapChef/Service/NetworkService.swift
@@ -24,23 +24,27 @@ struct NetworkService: NetworkServiceProtocol {
     func fetchData(urlRequest: URLRequest) async throws(NetworkError) -> Data {
         let maxRetries: Int = 3
         var currentAttempt = 1
-        
+
         while true {
             do {
                 let (data, response) = try await session.data(for: urlRequest)
-                
+
                 guard let httpResponse = response as? HTTPURLResponse else {
                     throw NetworkError.badResponse(statusCode: -1)
                 }
                 guard (200...299).contains(httpResponse.statusCode) else {
                     throw NetworkError.badResponse(statusCode: httpResponse.statusCode)
                 }
-                
+
                 return data
-                
+
             } catch {
                 if currentAttempt >= maxRetries {
-                    throw NetworkError.underlying(error)
+                    if let networkError = error as? NetworkError {
+                        throw networkError
+                    } else {
+                        throw NetworkError.underlying(error)
+                    }
                 }
                 currentAttempt += 1
             }


### PR DESCRIPTION
## Summary
- add missing Observation import
- preserve NetworkError when max retries are reached in NetworkService

## Testing
- `swiftc --version`


------
https://chatgpt.com/codex/tasks/task_e_68450c3a9c4083248ebf3a8d57ec8255